### PR TITLE
test github actions

### DIFF
--- a/src/devsite-paths.json
+++ b/src/devsite-paths.json
@@ -22,5 +22,11 @@
         "repo": "adp-devsite",
         "owner": "AdobeDocs",
         "root": "/src/pages/"
+    },
+    {
+        "pathPrefix": "/github-actions-test",
+        "repo": "adp-devsite-github-actions-test",
+        "owner": "AdobeDocs",
+        "root": "/src/pages/"
     }
 ]


### PR DESCRIPTION
Add [test repo](https://github.com/AdobeDocs/adp-devsite-github-actions-test) to devsite-paths in order to test `curl -XPOST -vi 'https://admin.hlx.page/preview/adobedocs/adp-devsite/main/github-actions-test/...`.

Hoping this fixes this error:

<img width="1249" alt="Screenshot 2024-08-22 at 2 51 54 PM" src="https://github.com/user-attachments/assets/e67051b5-700c-4833-be50-e66f70e40b85">

