### PR TITLE
do not require slots

### DIFF
--- a/src/steps/mdx-to-gridtables.ts
+++ b/src/steps/mdx-to-gridtables.ts
@@ -48,10 +48,10 @@ export default function mdxToBlocks(ctx: Helix.UniversalContext) {
     // get slots
     const slotsAttr = getAttribute(node, 'slots');
     const slotsValue = getAttributeValue(slotsAttr, '');
-    if (!slotsValue) {
-      // TODO: throw error for invalid document
-      break;
-    }
+    // if (!slotsValue) {
+    //   // TODO: throw error for invalid document
+    //   break;
+    // }
     const slots = slotsValue.split(',');
 
     // repeat the block N times if repeat="N" is set


### PR DESCRIPTION
**Issue:** Blocks without slots are getting left out of the markup

**Context:** Not all blocks have slots for example, 

- [InlineNestedAlert](https://github.com/adobe/aio-theme?tab=readme-ov-file#nested-inlinealert) 
- [RedoclyAPIBlock](https://github.com/adobe/aio-theme?tab=readme-ov-file#redoclyapiblock)
- [ProductCardGrid](https://github.com/adobe/aio-theme?tab=readme-ov-file#product-card-grid)
- [Accordion](https://github.com/adobe/aio-theme?tab=readme-ov-file#accordion)
- [GetCredential](https://github.com/adobe/aio-theme?tab=readme-ov-file#get-credential)

**Fix:** Don't require slots so that blocks without slots get included in the markup

**Before:**

<img width="1544" alt="before" src="https://github.com/user-attachments/assets/5f8cd9b3-c4b3-42a3-bb71-9c4e7e808233">


**After:**

<img width="1543" alt="after" src="https://github.com/user-attachments/assets/22ea4d52-32aa-46e0-8ad2-c244c842d448">

**Similar to how blocks with slots get included in the markup:**


<img width="1385" alt="other" src="https://github.com/user-attachments/assets/3d97296e-814e-4998-9dad-35147844b6b4">


