### PR TITLE
onboard acrobat-sign-developer-guide

### DIFF
--- a/src/devsite-paths.json
+++ b/src/devsite-paths.json
@@ -12,6 +12,12 @@
         "root": "/src/pages/"
     },
     {
+        "pathPrefix": "/acrobat-sign/developer-guide",
+        "repo": "acrobat-sign-developer-guide",
+        "owner": "AdobeDocs",
+        "root": "/src/pages/"
+    },
+    {
         "pathPrefix": "/analytics-apis/docs/2.0",
         "repo": "analytics-2.0-apis",
         "owner": "AdobeDocs",


### PR DESCRIPTION
Recommitting https://github.com/aemsites/devsite-runtime-connector/pull/15 since it was accidentally reverted