### PR TITLE
prepend attribute names with 'data-'

### DIFF
--- a/src/steps/mdx-to-gridtables.ts
+++ b/src/steps/mdx-to-gridtables.ts
@@ -71,7 +71,7 @@ export default function mdxToBlocks(ctx: Helix.UniversalContext) {
         .filter((attribute): attribute is MdxJsxAttribute => attribute != null)
         .map((attribute) => {
           const value = typeof attribute.value === 'string' ? attribute.value : attribute.value?.value;
-          return { type: 'code', value: `${attribute.name}=${value}` };
+          return { type: 'code', value: `data-${attribute.name}=${value}` };
         });
     } else {
       const totalRows = repeat * slots.length;


### PR DESCRIPTION
Prepend attribute names with `data-` so that we can differentiate in `adp-devsite` whether the slots contain actual contents vs. attributes

#### Before: 

<img width="999" alt="Screenshot 2024-11-22 at 11 50 05 AM" src="https://github.com/user-attachments/assets/4140b3a9-8af1-4111-95d8-21db974994b5">


#### After: 

<img width="950" alt="Screenshot 2024-11-22 at 11 50 16 AM" src="https://github.com/user-attachments/assets/7c62cbea-b941-4534-868d-db5281441616">
