### PR TITLE
fix: removed the attribute row if no attributes are present

### DIFF
--- a/src/steps/mdx-to-gridtables.ts
+++ b/src/steps/mdx-to-gridtables.ts
@@ -118,7 +118,7 @@ export default function mdxToBlocks(ctx: Helix.UniversalContext) {
               ],
             }),
             // Add attribute rows
-            ...attributeRows,
+            ...(attributeRows.length > 0 ? attributeRows : []),
             // Add content from the slots
             ...slotsToInsert.map(makeGridTableRow),
           ],


### PR DESCRIPTION
Removed attribute row when no attributes are present to avoid empty rows