### PR TITLE
update on not remove all classname

### DIFF
--- a/src/steps/remove-code-classes.ts
+++ b/src/steps/remove-code-classes.ts
@@ -18,7 +18,9 @@ export default function removeCodeClasses(ctx: Helix.UniversalContext) {
 
   visit(hast, (node) => {
     if (node.type === 'element' && node.tagName === 'code') {
-      delete node.properties.className;
+      if (node.properties.className.some(className => className.includes('language'))) {
+        delete node.properties.className;
+      }
     }
 
     return CONTINUE;

--- a/src/steps/remove-code-classes.ts
+++ b/src/steps/remove-code-classes.ts
@@ -18,7 +18,7 @@ export default function removeCodeClasses(ctx: Helix.UniversalContext) {
 
   visit(hast, (node) => {
     if (node.type === 'element' && node.tagName === 'code') {
-      if (node.properties.className.some(className => className.includes('language'))) {
+      if (!node.properties.className.some(className => className.includes('language'))) {
         delete node.properties.className;
       }
     }


### PR DESCRIPTION
Problem: class=“language-bash” is being removed in the code block so md file is missing the language highlights on the output. 
Solve: Checkif to make sure the className of the node doesn't include any language before removing the className. 
Output after fix:   <pre><code class="language-bash">aio login
        </code></pre>