### PR TITLE
fix: remove dupe paragraph

### DIFF
--- a/src/steps/mdx-to-gridtables.ts
+++ b/src/steps/mdx-to-gridtables.ts
@@ -126,7 +126,7 @@ export default function mdxToBlocks(ctx: Helix.UniversalContext) {
 
     const rowsToInsert = listToMatrix(slotsToInsert, slots.length);
 
-    mdast.children.splice(i, 1 + rowsToInsert.length, {
+    mdast.children.splice(i, 1 + totalSlots, {
       type: 'gridTable',
       children: [
         {


### PR DESCRIPTION
#### Issue
An extra `<p>` tag gets created with the last content for each block

#### Root cause 
Issue was introduced by this commit: https://github.com/aemsites/devsite-runtime-connector/commit/791567d38d629b1a7edc3ed09b224512c11a80ee

#### Fix
Remove the total number of slots from `mdast.children` (as it was doing before that commit), rather than the total number of rows.

Bug happens when totalRows < totalSlots, causing already processed slots to be left in `mdast.children`. This results in them getting re-processed as paragraphs a second time around.

#### Before

<img width="1728" alt="before" src="https://github.com/user-attachments/assets/b0aba7b2-b87a-409f-a475-646273424dac" />

#### After
<img width="1728" alt="after" src="https://github.com/user-attachments/assets/1894f893-c044-4532-97b9-24ca5c527e68" />

