### PR TITLE
anchor link fix

### DIFF
--- a/src/steps/rewrite-links.ts
+++ b/src/steps/rewrite-links.ts
@@ -27,9 +27,8 @@ export function resolve(ctx: Helix.UniversalContext, pathOrUrl: string, type: 'i
     pathprefix
   } = ctx.attributes.content;
 
-  // TODO clean up this logic - it's all over the place and not clear what it's doing
-  // - enforce strict trailing slashes when they apply (when it's the index.md file)
-  if (pathOrUrl.startsWith("http://") || pathOrUrl.startsWith("https://")){
+  // do not rewrite the links if it's an external link or an anchor link.
+  if (pathOrUrl.startsWith("http://") || pathOrUrl.startsWith("https://") || pathOrUrl.startsWith("#")){
     return pathOrUrl;
   }
 


### PR DESCRIPTION
We're currently rewriting the anchor links and it will fail if there is no .md file in front of the link because it will not add the path prefix to it. 

I'm going to not rewrite the anchor links if it's just an anchor link pointing back to the same file.  The rewrite link of anchor link is not needed. 