### PR TITLE
fix: guard against null node.meta

### DIFF
--- a/src/steps/to-hast.ts
+++ b/src/steps/to-hast.ts
@@ -30,7 +30,8 @@ const customHandlers = {
 
     // Parse the 'meta' string into a properties object.
     // This handles setting attributes e.g. <pre data-line="1-2, 5, 9-20"><code>
-    const keyValuePairs = Array.from(node.meta.matchAll(/(\S*)(\s*=\s*")(.*?)(")/g), (match) => [match[1], match[3]]);
+    const meta = node.meta ?? '';
+    const keyValuePairs = Array.from(meta.matchAll(/(\S*)(\s*=\s*")(.*?)(")/g), (match) => [match[1], match[3]]);
     const metaProperties = Object.fromEntries(keyValuePairs);
 
     if (pre && pre.type === 'element' && pre.tagName === 'pre') {


### PR DESCRIPTION
## Description
Guard against null `node.meta`

## Test
1. Run connector locally
2. Go to http://localhost:3000/app-builder/docs/guides/app_builder_guides/exc_app/interfaces/topbar-topbarapi.md

## Before
<img width="1390" alt="Screenshot 2025-05-27 at 3 04 41 PM" src="https://github.com/user-attachments/assets/3d97c7f8-8646-4ac2-87b9-f0bf18aafb05" />
<img width="805" alt="Screenshot 2025-05-27 at 3 04 58 PM" src="https://github.com/user-attachments/assets/a7600373-e411-4a2e-bcb9-482bad5bffae" />

## After
<img width="1183" alt="Screenshot 2025-05-27 at 3 04 13 PM" src="https://github.com/user-attachments/assets/944d5348-da4d-4dbd-8475-a023b4d8e8cb" />
