### PR TITLE
fix: revert pre code attributes

### DIFF
--- a/src/steps/to-hast.ts
+++ b/src/steps/to-hast.ts
@@ -19,41 +19,12 @@ import { Helix } from '@adobe/helix-universal';
 import { toHast as mdast2hast, defaultHandlers, State } from 'mdast-util-to-hast';
 import { raw } from 'hast-util-raw';
 import { mdast2hastGridTablesHandler, TYPE_TABLE } from '@adobe/mdast-util-gridtables';
-import { Code, Element } from 'mdast-util-to-hast/lib/handlers/code.js';
-
-const customHandlers = {
-
-  code(state: State, node: Code): Element | undefined {
-    // Call the default handler for 'code' to get the standard <pre><code> structure.
-    // This handles setting the 'language-xyz' class e.g. <pre><code class="language-xyz">
-    const pre = defaultHandlers.code(state, node);
-
-    // Parse the 'meta' string into a properties object.
-    // This handles setting attributes e.g. <pre data-line="1-2, 5, 9-20"><code>
-    const keyValuePairs = Array.from(node.meta.matchAll(/(\S*)(\s*=\s*")(.*?)(")/g), (match) => [match[1], match[3]]);
-    const metaProperties = Object.fromEntries(keyValuePairs);
-
-    if (pre && pre.type === 'element' && pre.tagName === 'pre') {
-      pre.properties = {
-        ...pre.properties,
-        ...metaProperties,
-      };
-    }
-
-    return pre;
-  },
-
-  // No other handlers are defined here.
-  // This means 'paragraph', 'heading', 'list', 'listItem', 'text', etc.,
-  // will all be processed by `mdast-util-to-hast`'s built-in `defaultHandlers`.
-
-};
 
 export default function toHast(ctx: Helix.UniversalContext) {
   const { content } = ctx.attributes;
   content.hast = mdast2hast(content.mdast, {
     handlers: {
-      ...customHandlers,
+      ...defaultHandlers,
       section: (state: State, node: any) => {
         const n = { ...node };
         const children = state.all(n);

--- a/src/steps/to-hast.ts
+++ b/src/steps/to-hast.ts
@@ -30,8 +30,7 @@ const customHandlers = {
 
     // Parse the 'meta' string into a properties object.
     // This handles setting attributes e.g. <pre data-line="1-2, 5, 9-20"><code>
-    const meta = node.meta ?? '';
-    const keyValuePairs = Array.from(meta.matchAll(/(\S*)(\s*=\s*")(.*?)(")/g), (match) => [match[1], match[3]]);
+    const keyValuePairs = Array.from(node.meta.matchAll(/(\S*)(\s*=\s*")(.*?)(")/g), (match) => [match[1], match[3]]);
     const metaProperties = Object.fromEntries(keyValuePairs);
 
     if (pre && pre.type === 'element' && pre.tagName === 'pre') {


### PR DESCRIPTION
## Description
Revert attempts to add attributes to `<pre><code>` because they will get stripped out by EDS:
- https://github.com/aemsites/devsite-runtime-connector/pull/54
- https://github.com/aemsites/devsite-runtime-connector/pull/55

## Context
https://jira.corp.adobe.com/browse/DEVSITE-1508?focusedId=48111450&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-48111450


