### PR TITLE
Revert unneeded code block logic

### DIFF
--- a/src/steps/to-hast.ts
+++ b/src/steps/to-hast.ts
@@ -19,91 +19,12 @@ import { Helix } from '@adobe/helix-universal';
 import { toHast as mdast2hast, defaultHandlers, State } from 'mdast-util-to-hast';
 import { raw } from 'hast-util-raw';
 import { mdast2hastGridTablesHandler, TYPE_TABLE } from '@adobe/mdast-util-gridtables';
-import type { Code } from 'mdast-util-to-hast/lib/handlers/code.js';
-import type { Element } from 'hast';
-
-export function code(state: State, node: Code): any {
-  const pre = defaultHandlers.code(state, node);
-  const meta = (node.meta ?? '').trim();
-
-  const codeAttrs: Record<string, string> = {};
-  const codeClasses: string[] = [];
-
-  // Robustly extract attributes and flags for <code>
-  const parseMeta = (input: string): Array<{ key: string; value?: string }> => {
-    const tokens: Array<{ key: string; value?: string }> = [];
-    let i = 0;
-    const n = input.length;
-    while (i < n) {
-      while (i < n && /\s/.test(input[i]!)) i++;
-      if (i >= n) break;
-      const keyStart = i;
-      while (i < n && !/\s|=/.test(input[i]!)) i++;
-      const key = input.slice(keyStart, i);
-      while (i < n && /\s/.test(input[i]!)) i++;
-      let value: string | undefined;
-      if (i < n && input[i] === '=') {
-        i++;
-        while (i < n && /\s/.test(input[i]!)) i++;
-        if (i < n && input[i] === '"') {
-          i++;
-          const valStart = i;
-          while (i < n && input[i] !== '"') i++;
-          value = input.slice(valStart, i);
-          if (i < n && input[i] === '"') i++;
-        } else {
-          const valStart = i;
-          while (i < n && !/\s/.test(input[i]!)) i++;
-          value = input.slice(valStart, i);
-        }
-      }
-      if (key) tokens.push({ key, value });
-    }
-    return tokens;
-  };
-
-  for (const { key, value } of parseMeta(meta)) {
-    if (key === 'disableLineNumbers' && value === undefined) {
-      codeClasses.push('disableLineNumbers');
-    } else if (key.startsWith('language-') && value === undefined) {
-      codeClasses.push(key);
-    } else if (value !== undefined) {
-      codeAttrs[key] = value;
-    } else {
-      codeAttrs[key] = '';
-    }
-  }
-
-  if (pre?.type === 'element' && pre.tagName === 'pre') {
-    // Add classes and attributes to <code> child only
-    const isCodeElement = (n: any): n is Element => n?.type === 'element' && n.tagName === 'code';
-    const codeEl = pre.children?.find?.(isCodeElement);
-    if (codeEl) {
-      // Merge classes
-      const existing = (codeEl.properties as any).className;
-      const base: Array<string | number> = Array.isArray(existing)
-        ? (existing as any[]).filter((v) => typeof v === 'string' || typeof v === 'number')
-        : typeof existing === 'string' || typeof existing === 'number'
-          ? [existing]
-          : [];
-      const allClasses: Array<string | number> = Array.from(new Set([...base, ...codeClasses]));
-      if (allClasses.length) (codeEl.properties as any).className = allClasses;
-      else delete (codeEl.properties as any).className;
-
-      // Merge attributes
-      Object.assign(codeEl.properties, codeAttrs);
-    }
-  }
-
-  return pre;
-}
 
 export default function toHast(ctx: Helix.UniversalContext) {
   const { content } = ctx.attributes;
   content.hast = mdast2hast(content.mdast, {
     handlers: {
       ...defaultHandlers,
-      code,
       section: (state: State, node: any) => {
         const n = { ...node };
         const children = state.all(n);


### PR DESCRIPTION
Reverting 2nd [attempt](https://github.com/aemsites/devsite-runtime-connector/pull/56) to add attributes to code tag, because it didn't work - [EDS still strips out attributes to code tag](https://adobeio.slack.com/archives/C06M1C7UBV3/p1757109499753899?thread_ts=1757109331.182939&cid=C06M1C7UBV3).

We don't need this anymore because we found an alternative way to [highlightLines and disableLineNumbers in Code block](https://github.com/AdobeDocs/adp-devsite/pull/294). It's by [overloading the languages keyword in the content](https://adobeio.slack.com/archives/C06M1C7UBV3/p1757112775000649?thread_ts=1757109331.182939&cid=C06M1C7UBV3):
- DevBiz
  - <img width="1506" height="448" alt="Screenshot 2025-10-29 at 2 10 27 PM" src="https://github.com/user-attachments/assets/e15b3737-ee87-4df7-8528-fa6f66445bc9" />
- DevDocs
  - <img width="1505" height="663" alt="Screenshot 2025-10-29 at 2 11 28 PM" src="https://github.com/user-attachments/assets/84e890eb-602b-4656-aae5-fa067f8207c8" />

