### PR TITLE
update for iframe to load as default node

### DIFF
--- a/src/steps/mdx-to-gridtables.ts
+++ b/src/steps/mdx-to-gridtables.ts
@@ -73,8 +73,8 @@ export default function mdxToBlocks(ctx: Helix.UniversalContext) {
 
     const isHorizontalLine = node.name === 'HorizontalLine';
 
-    const isFragment = node.name === 'Fragment';
-
+    // These components does not a fallback repeat
+    const isDefaultNode = node.name === 'Fragment' || node.name === 'iframe';
 
     // get slots
     const slotsAttr = getAttribute(node, 'slots');
@@ -87,7 +87,7 @@ export default function mdxToBlocks(ctx: Helix.UniversalContext) {
 
     // repeat the block N times if repeat="N" is set
     const repeatAttr = getAttribute(node, 'repeat');
-    const repeat = isFragment ? 0 : parseInt(getAttributeValue(repeatAttr, '1'), 10);
+    const repeat = isDefaultNode ? 0 : parseInt(getAttributeValue(repeatAttr, '1'), 10);
 
     // get variants as string
     const variantAttr = getAttribute(node, 'variant');


### PR DESCRIPTION
This is the same fix as fragment where we don't need these components to fallback to have 1 repeat as default. 

This will ensure the iframe to load properly with any contents following. 

test link
https://devsitse-2066-iframe-devdocs--adp-devsite--adobedocs.aem.page/github-actions-test/test/iframe

without the change there is only 1 important note but there should be 2 important note with this change
