### PR TITLE
refactor: consolidate 0-slots handling to rely on markdown

### DIFF
--- a/src/steps/mdx-to-gridtables.ts
+++ b/src/steps/mdx-to-gridtables.ts
@@ -72,11 +72,6 @@ export default function mdxToBlocks(ctx: Helix.UniversalContext) {
       continue;
     }
 
-    const isHorizontalLine = node.name === 'HorizontalLine';
-
-    // These components does not a fallback repeat
-    const isDefaultNode = node.name === 'Fragment' || node.name === 'iframe';
-
     // get slots
     const slotsAttr = getAttribute(node, 'slots');
     const slotsValue = getAttributeValue(slotsAttr, '');
@@ -84,16 +79,14 @@ export default function mdxToBlocks(ctx: Helix.UniversalContext) {
     //   // TODO: throw error for invalid document
     //   break;
     // }
-    const slots = isHorizontalLine
-      ? []
-      : slotsValue
+    const slots = slotsValue
         .split(',')
         .map((slot) => slot.trim())
         .filter((slot) => slot.length > 0);
 
     // repeat the block N times if repeat="N" is set
     const repeatAttr = getAttribute(node, 'repeat');
-    const repeat = isDefaultNode ? 0 : parseInt(getAttributeValue(repeatAttr, '1'), 10);
+    const repeat = parseInt(getAttributeValue(repeatAttr, '1'), 10);
 
     // get variants as string
     const variantAttr = getAttribute(node, 'variant');


### PR DESCRIPTION
## Description

Reduce the three ways we end up with 0 `slots` to a single approach.

Previous approaches:

- `HorizontalLine` - `slots` was forced to `[]`, so `totalSlots = repeat * 0 = 0`
- `Fragment` / `iframe` - `repeat` was forced to `0`, so `totalSlots = 0 * slots.length = 0`
- Missing/empty slots - When `slots` is missing or empty, parsing yields `[]`, so `totalSlots = repeat * 0 = 0`

All three produced 0 nodes consumed as `slot` content, but via different logic. This PR consolidates on # 3 to treat the markdown document as the source of truth - if a block has no `slots` attribute (or it's empty), treat it as 0 `slots`.

## Test
- HorizontalLine: testing blocked because HorizontalLine isn't rendered on stage: https://stage--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/test-hr-0
- Fragment: https://stage--adp-devsite--adobedocs.aem.page/github-actions-test/test/fragment

<img width="1519" height="1047" alt="Screenshot 2026-03-11 at 9 39 50 AM" src="https://github.com/user-attachments/assets/24f085b8-c865-4eb5-b54d-6b2386010128" />

<img width="1728" height="1045" alt="Screenshot 2026-03-11 at 9 34 39 AM" src="https://github.com/user-attachments/assets/3a580251-5975-4cad-b969-baa6023373b0" />

<img width="1535" height="976" alt="fragment" src="https://github.com/user-attachments/assets/da3179dd-d6cd-4ce1-82e2-fb4793b73572" />

- iframe: https://stage--adp-devsite--adobedocs.aem.page/github-actions-test/test/iframe 

<img width="1728" height="1048" alt="Screenshot 2026-03-11 at 8 07 19 AM" src="https://github.com/user-attachments/assets/83b93e9a-d8a3-440c-bff6-e87738dee807" />

- GetCredentials + RedoclyAPIBlock: https://stage--adp-devsite-stage--adobedocs.aem.page/cja-apis/docs/api
<img width="1728" height="1045" alt="Screenshot 2026-03-11 at 8 12 15 AM" src="https://github.com/user-attachments/assets/1bcc0a03-9c19-4a79-bd84-6d6866a58154" />

- RedoclyAPIBlock: https://stage--adp-devsite-stage--adobedocs.aem.page/github-actions-test/blocks/redoclyapiblock/redocly-api-block-default

<img width="1728" height="1045" alt="Screenshot 2026-03-11 at 8 10 23 AM" src="https://github.com/user-attachments/assets/c9fca935-d306-4d21-8735-91f38e81ffd1" />
