### PR TITLE
update dot url

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,9 @@ import md2markup from './md2markup.js';
 
 function getUrlExtension(url) {
   let extension;
-  if (url.split('.').length > 1) {
-    extension = url.split(/[#?]/)[0].split('.').pop().trim();
+  const lastSegment = url.split('/').pop() || '';
+  if (lastSegment.split('.').length > 1) {
+    extension = lastSegment.split(/[#?]/)[0].split('.').pop().trim();
   }
   return extension;
 }


### PR DESCRIPTION
I can only test this locally. http://localhost:3000/github-actions-test/test/2.0/version
Before the fix, it will 404 with the dot in the url:
<img width="1249" height="611" alt="Screenshot 2026-04-08 at 3 46 51 PM" src="https://github.com/user-attachments/assets/10cd2102-720b-427a-a4e3-0208bec30702" />

After the fix, it'll show properly
<img width="1623" height="571" alt="Screenshot 2026-04-08 at 3 44 24 PM" src="https://github.com/user-attachments/assets/e6c2968c-6abf-4b03-aefc-e40e08d58c76" />

