### PR TITLE
update links properly

### DIFF
--- a/src/steps/rewrite-links.ts
+++ b/src/steps/rewrite-links.ts
@@ -55,6 +55,8 @@ export function resolve(ctx: Helix.UniversalContext, pathOrUrl: string, type: 'i
   const relativePath = path.relative(projectRoot, resolved).replaceAll('\\', '/');
   if (resolved.endsWith('.md') || resolved.includes(".md#")) {
     resolved = `${pathprefix}/${relativePath}`;
+  } else if (type === 'a') {
+    resolved = `${pathprefix}/${relativePath}`;
   } else if (type === 'img') {
     // use this image URL
     const imageURL = `${projectRoot}${relativePath}`;
@@ -111,9 +113,9 @@ export default function rewriteLinks(ctx: Helix.UniversalContext) {
         else {
           node.properties[attr] = resolve(ctx, node.properties[attr] as string, node.tagName as 'img' | 'a');
         }
+      } else {
+        node.properties[attr] = resolve(ctx, node.properties[attr] as string, node.tagName as 'img' | 'a');
       }
-
-      node.properties[attr] = resolve(ctx, node.properties[attr] as string, node.tagName as 'img' | 'a');
 
     }
     return CONTINUE;


### PR DESCRIPTION
Previously:
https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/main/src/pages/openapi/index.md
the links will become 
https://developer-stage.adobe.com/github-actions-test/openapi/openapi/openapi/openapi.yaml
https://developer-stage.adobe.com/github-actions-test/openapi/openapi/openapi/test.csv
https://developer-stage.adobe.com/github-actions-test/openapi/openapi/DemoCode.zip

With Fix:
The links will be resolved correctly.
<img width="1292" height="509" alt="Screenshot 2026-04-16 at 1 31 42 PM" src="https://github.com/user-attachments/assets/8358f3fb-1b20-4c87-922c-8a798a829560" />
