### PR TITLE
fix: handle more file types and fix fetch for private sites

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export async function run(req: Request, ctx: Helix.UniversalContext): Promise<Re
   const { log } = ctx;
   ctx.attributes ??= {};
   ctx.attributes.content ??= {};
+  (ctx.attributes.content as { publicOrigin?: string }).publicOrigin = new URL(req.url).origin;
   log.debug('--------------------------------');
   log.debug(`    WEBSERVER_PORT: ${process.env.WEBSERVER_PORT}`);
   log.debug('ctx.pathInfo:', ctx.pathInfo);

--- a/src/steps/rewrite-links.ts
+++ b/src/steps/rewrite-links.ts
@@ -14,10 +14,71 @@ import { CONTINUE, visit } from 'unist-util-visit';
 import path from 'path';
 import type { Helix } from '@adobe/helix-universal';
 
+/** Private AdobeDocs orgs cannot use raw.githubusercontent.com; assets are served from the public site origin (see getResourceUrl in lib-adobeio.js). */
+export function isPrivateContentOrg(owner?: string): boolean {
+  return Boolean(owner && owner.includes('AdobeDocsPrivate'));
+}
+
+/** Extensions for `<a href>` targets resolved like `<img src>` (raw GitHub / public origin / local). */
+const REPO_ASSET_EXTENSIONS = new Set([
+  '7z',
+  'avif',
+  'csv',
+  'doc',
+  'docx',
+  'epub',
+  'gif',
+  'gz',
+  'ico',
+  'jpeg',
+  'jpg',
+  'json',
+  'mkv',
+  'mov',
+  'mp3',
+  'mp4',
+  'pdf',
+  'png',
+  'ppt',
+  'pptx',
+  'rar',
+  'svg',
+  'tar',
+  'tgz',
+  'txt',
+  'wasm',
+  'wav',
+  'webm',
+  'webp',
+  'xls',
+  'xlsx',
+  'xml',
+  'yaml',
+  'yml',
+  'zip',
+]);
+
+/** Anchor-only: same file resolution as images (raw GitHub / public origin / local). */
+function isRepoAssetExtension(resolvedPath: string): boolean {
+  const lower = resolvedPath.replace(/\\/g, '/').split('#')[0].split('?')[0].toLowerCase();
+  if (lower.endsWith('.tar.gz') || lower.endsWith('.d.ts')) {
+    return true;
+  }
+  const base = path.basename(lower);
+  const lastDot = base.lastIndexOf('.');
+  if (lastDot <= 0 || lastDot === base.length - 1) {
+    return false;
+  }
+  return REPO_ASSET_EXTENSIONS.has(base.slice(lastDot + 1));
+}
+
+const noopLog = { debug: (): void => {} };
+
 export function resolve(ctx: Helix.UniversalContext, pathOrUrl: string, type: 'img' | 'a') {
-  const { log } = ctx;
+  const log = ctx.log ?? noopLog;
 
 
+  const content = ctx.attributes.content!;
   const {
     root,
     path: docPath,
@@ -26,8 +87,9 @@ export function resolve(ctx: Helix.UniversalContext, pathOrUrl: string, type: 'i
     branch,
     pathprefix,
     localMode,
-    origin
-  } = ctx.attributes.content;
+    origin,
+  } = content;
+  const publicOrigin = (content as { publicOrigin?: string }).publicOrigin;
 
   // do not rewrite the links if it's an external link or an anchor link.
   if (pathOrUrl.startsWith("http://") || pathOrUrl.startsWith("https://") || pathOrUrl.startsWith("#") || pathOrUrl.startsWith("mailto:")){
@@ -55,20 +117,21 @@ export function resolve(ctx: Helix.UniversalContext, pathOrUrl: string, type: 'i
   const relativePath = path.relative(projectRoot, resolved).replaceAll('\\', '/');
   if (resolved.endsWith('.md') || resolved.includes(".md#")) {
     resolved = `${pathprefix}/${relativePath}`;
-  } else if (type === 'img') {
-    // use this image URL
-    const imageURL = `${projectRoot}${relativePath}`;
+  } else if (type === 'img' || isRepoAssetExtension(resolved)) {
+    const assetURL = `${projectRoot}${relativePath}`;
 
-    let fetchImage;
-    if(localMode) {
-      let flatPath = imageURL.replace('/src/pages', '');
-      fetchImage = `${origin}${flatPath}`;
+    let fetchAsset;
+    if (localMode) {
+      const flatPath = assetURL.replace('/src/pages', '');
+      fetchAsset = `${origin}${flatPath}`;
+    } else if (isPrivateContentOrg(owner) && publicOrigin && pathprefix) {
+      const prefix = pathprefix.startsWith('/') ? pathprefix : `/${pathprefix}`;
+      fetchAsset = `${publicOrigin}${prefix}/${relativePath}`;
     } else {
-      fetchImage = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}${imageURL}`;
+      fetchAsset = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}${assetURL}`;
     }
-    resolved = fetchImage;
+    resolved = fetchAsset;
     log.debug(`    resolved start: ${resolved}`);
-    resolved = `${resolved}`;
   }
 
   if(resolved === path.resolve(root)) {
@@ -81,7 +144,7 @@ export function resolve(ctx: Helix.UniversalContext, pathOrUrl: string, type: 'i
 }
 
 export default function rewriteLinks(ctx: Helix.UniversalContext) {
-  const { log } = ctx;
+  const log = ctx.log ?? noopLog;
   const { attributes: { content: { hast } } } = ctx;
 
   const els = {

--- a/test/rewrite-links.test.ts
+++ b/test/rewrite-links.test.ts
@@ -4,11 +4,25 @@
  */
 
 import { Helix } from '@adobe/helix-universal';
-import { resolve } from '../src/steps/rewrite-links.js';
+import { resolve, isPrivateContentOrg } from '../src/steps/rewrite-links.js';
 import rewriteLinks from '../src/steps/rewrite-links.js';
 import { DEFAULT_CONTEXT } from './util.js';
 
 describe('rewrite-links', () => {
+  describe('isPrivateContentOrg', () => {
+    it('returns true for AdobeDocsPrivate org', () => {
+      expect(isPrivateContentOrg('AdobeDocsPrivate')).to.equal(true);
+    });
+
+    it('returns false for public AdobeDocs org', () => {
+      expect(isPrivateContentOrg('AdobeDocs')).to.equal(false);
+    });
+
+    it('returns false when owner is missing', () => {
+      expect(isPrivateContentOrg(undefined)).to.equal(false);
+    });
+  });
+
   let ctx: Helix.UniversalContext;
 
   beforeEach(() => {
@@ -135,6 +149,50 @@ describe('rewrite-links', () => {
         expect(result).to.include('github-actions-test');
       });
 
+      it('should use public origin + pathprefix for private org images (remote mode)', () => {
+        const privateCtx = DEFAULT_CONTEXT({
+          attributes: {
+            content: {
+              root: '/src/pages/support',
+              path: '/src/pages/support/index.md',
+              pathprefix: '/private-eds',
+              owner: 'AdobeDocsPrivate',
+              repo: 'adp-dev-docs-private',
+              branch: 'main',
+              localMode: false,
+              origin: 'https://raw.githubusercontent.com',
+              publicOrigin: 'https://developer-stage.adobe.com',
+            },
+          },
+        });
+
+        const result = resolve(privateCtx, 'cc.png', 'img');
+        expect(result).to.equal(
+          'https://developer-stage.adobe.com/private-eds/support/cc.png',
+        );
+        expect(result).to.not.include('raw.githubusercontent.com');
+      });
+
+      it('should fall back to raw GitHub when publicOrigin is missing (private org)', () => {
+        const privateCtx = DEFAULT_CONTEXT({
+          attributes: {
+            content: {
+              root: '/src/pages/support',
+              path: '/src/pages/support/index.md',
+              pathprefix: '/private-eds',
+              owner: 'AdobeDocsPrivate',
+              repo: 'adp-dev-docs-private',
+              branch: 'main',
+              localMode: false,
+              origin: 'https://raw.githubusercontent.com',
+            },
+          },
+        });
+
+        const result = resolve(privateCtx, 'cc.png', 'img');
+        expect(result).to.include('raw.githubusercontent.com');
+      });
+
       it('should generate local URL for images (local mode)', () => {
         const localCtx = DEFAULT_CONTEXT({
           attributes: {
@@ -153,6 +211,73 @@ describe('rewrite-links', () => {
 
         const result = resolve(localCtx, './images/screenshot.png', 'img');
         expect(result).to.include('127.0.0.1:3003');
+      });
+    });
+
+    describe('Anchor hrefs to downloadable / static assets', () => {
+      it('should generate GitHub raw URL for .zip (remote, public org)', () => {
+        const result = resolve(ctx, './assets/sample.zip', 'a');
+        expect(result).to.include('raw.githubusercontent.com');
+        expect(result).to.include('AdobeDocs');
+        expect(result).to.include('github-actions-test');
+        expect(result).to.include('sample.zip');
+      });
+
+      it('should generate GitHub raw URL for .pdf (remote, public org)', () => {
+        const result = resolve(ctx, './assets/guide.pdf', 'a');
+        expect(result).to.include('raw.githubusercontent.com');
+        expect(result).to.include('guide.pdf');
+      });
+
+      it('should generate GitHub raw URL for .d.ts (remote, public org)', () => {
+        const result = resolve(ctx, './types/example.d.ts', 'a');
+        expect(result).to.include('raw.githubusercontent.com');
+        expect(result).to.include('example.d.ts');
+      });
+
+      it('should use public origin + pathprefix for private org .zip anchor', () => {
+        const privateCtx = DEFAULT_CONTEXT({
+          attributes: {
+            content: {
+              root: '/src/pages/support',
+              path: '/src/pages/support/index.md',
+              pathprefix: '/private-eds',
+              owner: 'AdobeDocsPrivate',
+              repo: 'adp-dev-docs-private',
+              branch: 'main',
+              localMode: false,
+              origin: 'https://raw.githubusercontent.com',
+              publicOrigin: 'https://developer-stage.adobe.com',
+            },
+          },
+        });
+
+        const result = resolve(privateCtx, './assets/bundle.zip', 'a');
+        expect(result).to.equal(
+          'https://developer-stage.adobe.com/private-eds/support/assets/bundle.zip',
+        );
+        expect(result).to.not.include('raw.githubusercontent.com');
+      });
+
+      it('should use local content origin for .zip in local mode', () => {
+        const localCtx = DEFAULT_CONTEXT({
+          attributes: {
+            content: {
+              root: '/src/pages/test',
+              path: '/src/pages/test/test-page.md',
+              pathprefix: '/github-actions-test/test',
+              owner: 'AdobeDocs',
+              repo: 'github-actions-test',
+              branch: 'main',
+              localMode: true,
+              origin: 'http://127.0.0.1:3003',
+            },
+          },
+        });
+
+        const result = resolve(localCtx, './files/demo.zip', 'a');
+        expect(result).to.include('127.0.0.1:3003');
+        expect(result).to.include('demo.zip');
       });
     });
   });


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/DEVSITE-2364

- Add Set of allowed file types like `PDFs`and `ZIP` files under: `REPO_ASSET_EXTENSIONS`. Function  `isRepoAssetExtension` returns `true` for those file types (Davide also requested files like`.d.ts`) and when checking for images also check for those file types since they need to be fetched in a similar way
- Add check for sites under `AdobeDocsPrivate` and fetch images and other file types from the public origin (either `developer.adobe.com`or `developer-stage.adobe.com`)

Added tests for these cases:
- describe('isPrivateContentOrg')
returns `true` for AdobeDocsPrivate org
returns `false` for public AdobeDocs org
returns `false` when owner is missing
- describe('Image handling') (new cases)
should use public origin + pathprefix for private org images (remote mode)
should fall back to raw GitHub when publicOrigin is missing (private org)
- describe('Anchor hrefs to downloadable / static assets')
should generate GitHub raw URL for .zip (remote, public org)
should generate GitHub raw URL for .pdf (remote, public org)
should generate GitHub raw URL for .d.ts (remote, public org)
should use public origin + pathprefix for private org .zip anchor
should use local content origin for .zip in local mode