### PR TITLE
fix: urls that start with www

### DIFF
--- a/src/steps/rewrite-links.ts
+++ b/src/steps/rewrite-links.ts
@@ -107,7 +107,7 @@ export function resolve(ctx: Helix.UniversalContext, pathOrUrl: string, type: 'i
   const publicOrigin = usePublicAssetUrls ? devSiteConnectorPublicOrigin() : undefined;
 
   // do not rewrite the links if it's an external link or an anchor link.
-  if (pathOrUrl.startsWith("http://") || pathOrUrl.startsWith("https://") || pathOrUrl.startsWith("#") || pathOrUrl.startsWith("mailto:")){
+  if (pathOrUrl.startsWith("www") || pathOrUrl.startsWith("http://") || pathOrUrl.startsWith("https://") || pathOrUrl.startsWith("#") || pathOrUrl.startsWith("mailto:")){
     return pathOrUrl;
   }
 

--- a/test/rewrite-links.test.ts
+++ b/test/rewrite-links.test.ts
@@ -144,10 +144,10 @@ describe('rewrite-links', () => {
       expect(result).to.equal('/github-actions-test/test/test/anchor-link-in-table.md#request-object');
     });
 
-    it('external link with no http and https should fail', () => {
+    it('external link with no http and https should not be rewritten', () => {
       const result = resolve(ctx, 'www.google.com', 'a');
       // www.google.com is not recognized as external, so it gets rewritten as a relative path
-      expect(result).to.equal('/www.google.com');
+      expect(result).to.equal('www.google.com');
     });
 
     describe('Links that already have pathprefix', () => {


### PR DESCRIPTION
As described in this ticket: https://jira.corp.adobe.com/browse/DEVSITE-1971
Urls that start with `www` gets incorrectly prepended with the origin of the url:
https://stage--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/test-url#external-link-with-no-http-and-https-should-fail

