### PR TITLE
fix: clean asset paths for private sites

### DIFF
--- a/src/steps/rewrite-links.ts
+++ b/src/steps/rewrite-links.ts
@@ -142,7 +142,12 @@ export function resolve(ctx: Helix.UniversalContext, pathOrUrl: string, type: 'i
       fetchAsset = `${origin}${flatPath}`;
     } else if (isPrivateContentOrg(owner) && usePublicAssetUrls && pathprefix) {
       const prefix = pathprefix.startsWith('/') ? pathprefix : `/${pathprefix}`;
-      fetchAsset = `${publicOrigin}${prefix}/${relativePath}`;
+      // Remove leading / and any ../ or ./ segments to get private site path
+      const assetSitePath = relativePath
+        .split('/')
+        .filter((p) => p !== '..' && p !== '.')
+        .join('/');
+      fetchAsset = `${publicOrigin}${prefix}/${assetSitePath}`;
     } else {
       fetchAsset = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}${assetURL}`;
     }


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/DEVSITE-2364

Issue: the paths for json files in static are not correct (still have all of the relative path `..` and .`./` in the paths)
<img width="636" height="218" alt="Screenshot 2026-05-18 at 4 11 13 PM" src="https://github.com/user-attachments/assets/5fb73b58-479f-4f05-a0ae-d17dd01a314e" />

Fix: clean up the paths for private sites so they are just:

`publicOrigin/prefix/assetSitePath`

where assetSitePath has no leading trailing slashes
