### PR TITLE
DEVSITE-2416 - read noToc from md metadata to hide ON THIS PAGE

### DIFF
--- a/src/steps/stringify.ts
+++ b/src/steps/stringify.ts
@@ -27,7 +27,7 @@ function wrapHtml(
   title?: string,
   description?: string,
   searchKeywords? : string,
-  noToc?: string,
+  noOnThisPage?: string,
 ): string {
   const documentationString = '<meta name="template" content="documentation">';
   return `\
@@ -47,7 +47,7 @@ function wrapHtml(
     ${hideLogIssue ? `<meta name="hidelogissue" content="${hideLogIssue}">` : ''}
     ${hideCopyMarkdown ? `<meta name="hidecopymarkdown" content="${hideCopyMarkdown}">` : ''}
     ${layout ? `<meta name="layout" content="${layout}">` : ''}
-    ${noToc ? `<meta name="no-toc" content="${noToc}">` : ''}
+    ${noOnThisPage ? `<meta name="noonthispage" content="${noOnThisPage}">` : ''}
   </head>
   <body>
     <header></header>
@@ -125,8 +125,8 @@ export default function stringify(ctx: Helix.UniversalContext) {
   const docTitle = parseVariable(ctx.attributes.content.md, "title:", log);
   const docDescription = parseVariable(ctx.attributes.content.md, "description:", log);
   const searchKeywords = parseVariable(ctx.attributes.content.md, "keywords:", log);
-  const noToc = parseVariable(ctx.attributes.content.md, "no-toc:", log);
+  const noOnThisPage = parseVariable(ctx.attributes.content.md, "noOnThisPage:", log);
   content.html = wrapHtml(toHtml(content.hast, {
     upperDoctype: true,
-  }), pathprefix, githubBlobPath, documetationMode, hideBreadcrumbNav, hideEditInGitHub, hideLogIssue, hideCopyMarkdown, layout, docTitle, docDescription, searchKeywords, noToc);
+  }), pathprefix, githubBlobPath, documetationMode, hideBreadcrumbNav, hideEditInGitHub, hideLogIssue, hideCopyMarkdown, layout, docTitle, docDescription, searchKeywords, noOnThisPage);
 }

--- a/src/steps/stringify.ts
+++ b/src/steps/stringify.ts
@@ -27,6 +27,7 @@ function wrapHtml(
   title?: string,
   description?: string,
   searchKeywords? : string,
+  noToc?: string,
 ): string {
   const documentationString = '<meta name="template" content="documentation">';
   return `\
@@ -46,6 +47,7 @@ function wrapHtml(
     ${hideLogIssue ? `<meta name="hidelogissue" content="${hideLogIssue}">` : ''}
     ${hideCopyMarkdown ? `<meta name="hidecopymarkdown" content="${hideCopyMarkdown}">` : ''}
     ${layout ? `<meta name="layout" content="${layout}">` : ''}
+    ${noToc ? `<meta name="no-toc" content="${noToc}">` : ''}
   </head>
   <body>
     <header></header>
@@ -123,7 +125,8 @@ export default function stringify(ctx: Helix.UniversalContext) {
   const docTitle = parseVariable(ctx.attributes.content.md, "title:", log);
   const docDescription = parseVariable(ctx.attributes.content.md, "description:", log);
   const searchKeywords = parseVariable(ctx.attributes.content.md, "keywords:", log);
+  const noToc = parseVariable(ctx.attributes.content.md, "no-toc:", log);
   content.html = wrapHtml(toHtml(content.hast, {
     upperDoctype: true,
-  }), pathprefix, githubBlobPath, documetationMode, hideBreadcrumbNav, hideEditInGitHub, hideLogIssue, hideCopyMarkdown, layout, docTitle, docDescription, searchKeywords);
+  }), pathprefix, githubBlobPath, documetationMode, hideBreadcrumbNav, hideEditInGitHub, hideLogIssue, hideCopyMarkdown, layout, docTitle, docDescription, searchKeywords, noToc);
 }

--- a/src/steps/stringify.ts
+++ b/src/steps/stringify.ts
@@ -27,7 +27,7 @@ function wrapHtml(
   title?: string,
   description?: string,
   searchKeywords? : string,
-  noOnThisPage?: string,
+  hideOnThisPage?: string,
 ): string {
   const documentationString = '<meta name="template" content="documentation">';
   return `\
@@ -47,7 +47,7 @@ function wrapHtml(
     ${hideLogIssue ? `<meta name="hidelogissue" content="${hideLogIssue}">` : ''}
     ${hideCopyMarkdown ? `<meta name="hidecopymarkdown" content="${hideCopyMarkdown}">` : ''}
     ${layout ? `<meta name="layout" content="${layout}">` : ''}
-    ${noOnThisPage ? `<meta name="noonthispage" content="${noOnThisPage}">` : ''}
+    ${hideOnThisPage ? `<meta name="hideonthispage" content="${hideOnThisPage}">` : ''}
   </head>
   <body>
     <header></header>
@@ -125,8 +125,8 @@ export default function stringify(ctx: Helix.UniversalContext) {
   const docTitle = parseVariable(ctx.attributes.content.md, "title:", log);
   const docDescription = parseVariable(ctx.attributes.content.md, "description:", log);
   const searchKeywords = parseVariable(ctx.attributes.content.md, "keywords:", log);
-  const noOnThisPage = parseVariable(ctx.attributes.content.md, "noOnThisPage:", log);
+  const hideOnThisPage = parseVariable(ctx.attributes.content.md, "hideOnThisPage:", log);
   content.html = wrapHtml(toHtml(content.hast, {
     upperDoctype: true,
-  }), pathprefix, githubBlobPath, documetationMode, hideBreadcrumbNav, hideEditInGitHub, hideLogIssue, hideCopyMarkdown, layout, docTitle, docDescription, searchKeywords, noOnThisPage);
+  }), pathprefix, githubBlobPath, documetationMode, hideBreadcrumbNav, hideEditInGitHub, hideLogIssue, hideCopyMarkdown, layout, docTitle, docDescription, searchKeywords, hideOnThisPage);
 }


### PR DESCRIPTION
JIRA: [DEVSITE-2416](https://jira.corp.adobe.com/browse/DEVSITE-2416)

This code change involved another metadata field reading: `hideOnThisPage`. If the md has `hideOnThisPage: true`, the ON THIS PAGE side nav bar will not be rendered